### PR TITLE
up_device_removed_cb has incorrect signature

### DIFF
--- a/Frameworks/SystemKit/OSEPower.m
+++ b/Frameworks/SystemKit/OSEPower.m
@@ -117,9 +117,9 @@ up_device_added_cb(UpClient *client, UpDevice *device, gpointer user_data)
   NSLog(@"OSEPower: device %s added", up_device_to_text(device));
 }
 static void
-up_device_removed_cb(UpClient *client, UpDevice *device, gpointer user_data)
+up_device_removed_cb(UpClient *client, char *object_path, gpointer user_data)
 {
-  NSLog(@"OSEPower: device %s removed", up_device_to_text(device));
+  NSLog(@"OSEPower: device %s removed", object_path);
 }
 static void
 up_lid_closed_cb(UpClient *client, gpointer user_data)


### PR DESCRIPTION
see https://upower.freedesktop.org/docs/UpClient.html#up-client-new

Description: When a power device is removed, the Preferences app crashes.

Steps to reproduce problem
- connect a Bluetooth mouse
- start the Preferences app (openapp Preferences to see logs)
- go to the 'Screen Preferences' panel (this starts the OSEPower monitoring)
- turn off the Bluetooth Mouse
   - the Preferences app crashes

Instead, what you should see is a log message like

2024-01-05 15:51:19.403 Preferences[3767:3767] OSEPower: device /org/freedesktop/UPower/devices/battery_hid_34o88o5do91o9aob6_battery removed

I believe this bug also caused Preferences to crash when the laptop lid was closed while Preferences was running.