### PR TITLE
OSEDisplay retain bug, OSEScreen resize issue

### DIFF
--- a/Frameworks/SystemKit/OSEDisplay.m
+++ b/Frameworks/SystemKit/OSEDisplay.m
@@ -148,6 +148,7 @@
   NSSize       resSize;
   NSDictionary *res;
   CGFloat      r;
+  NSDictionary *resolution = nil;
   
   for (res in allResolutions)
     {
@@ -156,15 +157,16 @@
           resSize.height == mode_info.height &&
           [[res objectForKey:OSEDisplayRateKey] floatValue] == _activeRate)
         {
+	  resolution = [res retain];
           break;
         }
       else
         {
-          res = nil;
+          resolution = nil;
         }
     }
 
-  return res;
+  return resolution;
 }
 
 // Names are coming from kernel video and drm drivers:
@@ -358,7 +360,7 @@
             {
               if ((float)refresh == (float)resRate)
                 {
-                  resolution = res;
+                  resolution = [res retain];
                   break;
                 }
             }

--- a/Frameworks/SystemKit/OSEScreen.m
+++ b/Frameworks/SystemKit/OSEScreen.m
@@ -1027,8 +1027,12 @@ static OSEScreen *systemScreen = nil;
      Example: current size is 1440x900, new size 1280x960. Height is bigger
      but width is smaller. In VirtualBox this leads to - X Error: 
      BadMatch (invalid parameter attributes). */
-  if (newPixSize.width > sizeInPixels.width &&
-      newPixSize.height > sizeInPixels.height) {
+  if ((newPixSize.width > sizeInPixels.width &&
+       newPixSize.height > sizeInPixels.height) ||
+      (newPixSize.width > sizeInPixels.width &&
+       newPixSize.height == sizeInPixels.height) ||
+      (newPixSize.width == sizeInPixels.width &&
+       newPixSize.height > sizeInPixels.height)) {
     NSDebugLLog(@"Screen", @"OSEScreen: set new BIGGER screen size: START");
     XRRSetScreenSize(xDisplay, xRootWindow,
                      (int)newPixSize.width, (int)newPixSize.height,


### PR DESCRIPTION
OSEDisplay.m retain bug described in https://github.com/onflapp/gs-desktop/issues/30

OSEScreen.m detail when only one dimension changes when adding a Display